### PR TITLE
Fix: Add project root to sys.path to resolve pytest errors

### DIFF
--- a/src/peer.py
+++ b/src/peer.py
@@ -6,6 +6,9 @@ import hashlib
 import argparse
 import pickle
 
+from pathlib import Path
+sys.path.append(str(Path(__file__).resolve().parent.parent))
+
 from utils import simsocket
 from utils.simsocket import AddressType
 from utils.peer_context import PeerContext


### PR DESCRIPTION
## Description

This PR addresses the `ModuleNotFoundError` when running `pytest` by appending the project root to `sys.path`.

## Related Issue

Addresses #1 
(Note: Intentionally not closing it to keep it visible for other students.)
