### PR TITLE
Remove default `--timeout 60` for peer in `grader.py`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 All notable changes to this project will be documented in this file.
 
+## [2025-12-18]
+
+### Change
+
+- **Remove default `--timeout 60` for peer in `grader.py`** - [#15](https://github.com/OctCarp/sustech-cs305-f25-project-starter/pull/15)
+
 ## [2025-12-05]
 
 ### Add

--- a/README.md
+++ b/README.md
@@ -4,12 +4,15 @@ For SUSTech CS305 Fall 2025: P2P File Transfer with Reliable Data Transfer
 
 ## 📢 Important Updates
 
+- **[2025-12-18]**
+  - Remove default `--timeout 60` for peer in `grader.py` - [#15](https://github.com/OctCarp/sustech-cs305-f25-project-starter/pull/15)
+
 - **[2025-12-05]**
   - Add public comprehensive tests 05 06 - [#9](https://github.com/OctCarp/sustech-cs305-f25-project-starter/pull/9)
 
 - **[2025-12-04]**
   - Add requirement and example for congestion control in Setup-tutorial to Section 5 - [#7](https://github.com/OctCarp/sustech-cs305-f25-project-starter/pull/7)
-  
+
 - **[2025-11-24]**
   - Fix potential `ModuleNotFoundError` in test scripts - [#3](https://github.com/OctCarp/sustech-cs305-f25-project-starter/pull/3)
   - Clarify usage rules for the socket module - [#4](https://github.com/OctCarp/sustech-cs305-f25-project-starter/pull/4)

--- a/test/grader.py
+++ b/test/grader.py
@@ -27,7 +27,7 @@ class PeerProc:
         node_map_loc: str,
         has_chunk_loc: str,
         max_transmit: int = 1,
-        timeout: int = 60,
+        timeout: int | None = None,
     ) -> None:
         self.id: int = identity
         self.peer_file_loc: str = peer_file_loc
@@ -41,7 +41,7 @@ class PeerProc:
         self.recv_record: dict[tuple[str, int], dict[int, int]] = (
             {}
         )  # {from_id:{type:cnt}}
-        self.timeout: int = timeout
+        self.timeout: int | None = timeout
 
     def _get_command_args(self) -> list[str]:
         module_name: str = self.peer_file_loc
@@ -182,7 +182,7 @@ class GradingSession:
         has_chunk_loc: str,
         max_connection: int,
         peer_addr: tuple[str, int],
-        timeout: int | None = 60,
+        timeout: int | None = None,
     ) -> None:
         peer: PeerProc = PeerProc(
             identity,


### PR DESCRIPTION
## Description

This PR removes default timeout 60 in `grader.py`

We should allow students to use their own timeout mechanism.

## Related Issue

Closes #14 